### PR TITLE
[FIX] XSS using htmlentities()

### DIFF
--- a/bl-kernel/admin/views/edit-category.php
+++ b/bl-kernel/admin/views/edit-category.php
@@ -31,7 +31,7 @@
 	echo Bootstrap::formInputText(array(
 		'name'=>'name',
 		'label'=>$L->g('Name'),
-		'value'=>$categoryMap['name'],
+		'value'=>htmlentities($categoryMap['name'], ENT_QUOTES, 'UTF-8'),
 		'class'=>'',
 		'placeholder'=>'',
 		'tip'=>''
@@ -50,7 +50,7 @@
 	echo Bootstrap::formInputText(array(
 		'name'=>'template',
 		'label'=>$L->g('Template'),
-		'value'=>isset($categoryMap['template'])?$categoryMap['template']:'',
+		'value'=>isset($categoryMap['template'])?htmlentities($categoryMap['template'], ENT_QUOTES, 'UTF-8'):'',
 		'class'=>'',
 		'placeholder'=>'',
 		'tip'=>''


### PR DESCRIPTION
### 📊 Metadata *

#### Bounty URL: https://www.huntr.dev/bounties/1-other-bludit

### ⚙️ Description *

A `XSS` issue occurred in the `edit-category` page, which allowed to `inject` arbitrary `HTML tags`.
The issue was due to a `unsafe reflection` of the `user-supplied` inputs given which identified the `category` it-self (`name` and `template`).

### 💻 Technical Description *

I used the `htmlentities` function to patch the issue and avoid that `HTML tags` and `quotes` could modify the `HTML structure` of the page.

### 🐛 Proof of Concept (PoC) *

1. Download the project
2. Open a server on the `root` of the project ( `php -S 0.0.0.0:8001`)
3. Setup `bludit`
4. Go on http://0.0.0.0:8001/admin/ and `add a category` called `" onfocus="alert(1)" autofocus="`
5. Go on http://0.0.0.0:8001/admin/edit-category/<category_name>
6. XSS triggered

![Screenshot from 2020-08-17 16-37-56](https://user-images.githubusercontent.com/33063403/90408482-2817d700-e0a8-11ea-8bba-aa44cce65012.png)

### 🔥 Proof of Fix (PoF) *

Same steps of above with the `fixed` version

![Screenshot from 2020-08-17 16-28-47](https://user-images.githubusercontent.com/33063403/90408411-146c7080-e0a8-11ea-8dbd-877fcdb0e4f4.png)

### 👍 User Acceptance Testing (UAT)

Only `sanitized` the `strings` passed to the `view` with `htmlentities()` :smile: