### PR TITLE
Fixed xss on social buttons

### DIFF
--- a/bl-kernel/helpers/sanitize.class.php
+++ b/bl-kernel/helpers/sanitize.class.php
@@ -30,6 +30,12 @@ class Sanitize {
 		return htmlspecialchars_decode($text, $flags);
 	}
 
+	// Remove javacript from links
+	public static function noJSLink($text)
+	{
+		return preg_replace("/javascript\s*:\s*/", "", $text);
+	}
+
 	public static function pathFile($path, $file=false)
 	{
 		if ($file!==false){

--- a/bl-kernel/helpers/sanitize.class.php
+++ b/bl-kernel/helpers/sanitize.class.php
@@ -30,10 +30,14 @@ class Sanitize {
 		return htmlspecialchars_decode($text, $flags);
 	}
 
-	// Remove javacript from links
+	// Remove javascript from links
 	public static function noJSLink($text)
 	{
-		return preg_replace("/javascript\s*:\s*/", "", $text);
+		$text = trim($text);
+		while(strpos($text, 'javascript')===0){
+			$text = preg_replace("/javascript\s*:\s*/", "", $text);
+		}
+		return $text;
 	}
 
 	public static function pathFile($path, $file=false)

--- a/bl-kernel/helpers/sanitize.class.php
+++ b/bl-kernel/helpers/sanitize.class.php
@@ -33,8 +33,8 @@ class Sanitize {
 	// Remove javascript from links
 	public static function noJSLink($text)
 	{
-		$text = trim($text);
-		while(strpos($text, 'javascript')===0){
+		$text = preg_replace("/\s+/", "", $text);
+		while(strpos($text, 'javascript:')===0){
 			$text = preg_replace("/javascript\s*:\s*/", "", $text);
 		}
 		return $text;

--- a/bl-kernel/site.class.php
+++ b/bl-kernel/site.class.php
@@ -73,7 +73,7 @@ class Site extends dbJSON {
 		foreach ($this->dbFields as $field=>$value) {
 			if (isset($args[$field])) {
 				$finalValue = Sanitize::html($args[$field]);
-				$finalValue = Sanitize::noJSLink($args[$field]);
+				$finalValue = Sanitize::noJSLink($finalValue);
 				if ($finalValue==='false') { $finalValue = false; }
 				elseif ($finalValue==='true') { $finalValue = true; }
 				settype($finalValue, gettype($value));

--- a/bl-kernel/site.class.php
+++ b/bl-kernel/site.class.php
@@ -73,6 +73,7 @@ class Site extends dbJSON {
 		foreach ($this->dbFields as $field=>$value) {
 			if (isset($args[$field])) {
 				$finalValue = Sanitize::html($args[$field]);
+				$finalValue = Sanitize::noJSLink($args[$field]);
 				if ($finalValue==='false') { $finalValue = false; }
 				elseif ($finalValue==='true') { $finalValue = true; }
 				settype($finalValue, gettype($value));

--- a/bl-kernel/site.class.php
+++ b/bl-kernel/site.class.php
@@ -49,6 +49,18 @@ class Site extends dbJSON {
 		'markdownParser'=>	true,
 		'customFields'=>	'{}'
 	);
+	private $linkKeys = array(
+		'twitter',
+		'facebook',
+		'codepen',
+		'instagram',
+		'github',
+		'gitlab',
+		'linkedin',
+		'mastodon',
+		'dribbble',
+		'vk'
+	);
 
 	function __construct()
 	{
@@ -74,6 +86,11 @@ class Site extends dbJSON {
 			if (isset($args[$field])) {
 				$finalValue = Sanitize::html($args[$field]);
 				$finalValue = Sanitize::noJSLink($finalValue);
+				if (in_array($field,$this->linkKeys)){
+					if (!filter_var($finalValue, FILTER_VALIDATE_URL, FILTER_FLAG_SCHEME_REQUIRED | FILTER_FLAG_HOST_REQUIRED)) {
+						$finalValue = "";
+					}
+				}
 				if ($finalValue==='false') { $finalValue = false; }
 				elseif ($finalValue==='true') { $finalValue = true; }
 				settype($finalValue, gettype($value));


### PR DESCRIPTION
### 📊 Metadata *



#### Bounty URL: https://www.huntr.dev/bounties/3-other-bludit/

### ⚙️ Description *

Avoid code execution from social buttons

### 💻 Technical Description *

Avoid XSS by removing 'javascript:' from settings values using 'preg_replace' additionaly verify social media links are valid urls

### 🐛 Proof of Concept (PoC) *

Saving javascript:alert('hola') as link for social media triggers code execution when clicking link

![Captura de pantalla de 2020-08-28 20-21-52](https://user-images.githubusercontent.com/7505980/91595506-516c1900-e96c-11ea-8e8f-5746c4e5dd94.png)

![Captura de pantalla de 2020-08-28 20-22-12](https://user-images.githubusercontent.com/7505980/91595503-50d38280-e96c-11ea-9c7b-6ccffd9e4206.png)

### 🔥 Proof of Fix (PoF) *

After fix javascript is removed and no link inserted

![Captura de pantalla de 2020-08-28 21-15-14](https://user-images.githubusercontent.com/7505980/91602214-9e072280-e973-11ea-8674-745a61f10e2f.png)

![Captura de pantalla de 2020-08-28 21-15-20](https://user-images.githubusercontent.com/7505980/91602209-9cd5f580-e973-11ea-9ef9-2a3326d1326d.png)

### 👍 User Acceptance Testing (UAT)

Functionality unafected
![Captura de pantalla de 2020-08-28 20-24-34](https://user-images.githubusercontent.com/7505980/91595641-8aa48900-e96c-11ea-9a9d-d906cd2c464a.png)
